### PR TITLE
Use find_library to detect libmysqlclient

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project(librms)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED)
+find_library(MYSQLCLIENT_LIB mysqlclient
+  HINTS /usr/lib/mysql)
+if (NOT MYSQLCLIENT_LIB)
+  message(FATAL_ERROR "mysqlclient not found")
+endif()
 
 ###################################################
 ## Declare things to be passed to other projects ##
@@ -15,7 +20,7 @@ find_package(catkin REQUIRED)
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES rms mysqlclient
+  LIBRARIES rms ${MYSQLCLIENT_LIB}
 )
 
 ###########
@@ -43,7 +48,7 @@ add_library(rms ${LIBRMS_SOURCE})
 ## Specify libraries to link a library or executable target against
 target_link_libraries(rms
   ${catkin_LIBRARIES}
-  mysqlclient
+  ${MYSQLCLIENT_LIB}
 )
 
 #############


### PR DESCRIPTION
Fedora packages libmysqlclient.so in the mysql subdirectory of the
system library directory, which means that passing -lmysqlclient
to the linker will result in a linking error.  This commit adds
logic to search for libmysqlclient.so on the current library paths
as well as the system-wide path /usr/lib/mysql.

Signed-off-by: Rich Mattes richmattes@gmail.com
